### PR TITLE
chore: Update image preview height in create pages

### DIFF
--- a/app/Filament/Clusters/Frontends/Resources/BoardOfTrusteeResource/Pages/CreateBoardOfTrustee.php
+++ b/app/Filament/Clusters/Frontends/Resources/BoardOfTrusteeResource/Pages/CreateBoardOfTrustee.php
@@ -43,7 +43,7 @@ class CreateBoardOfTrustee extends CreateRecord
                     ->hint(__('Maximum size: 5MB.'))
                     ->hintIcon('heroicon-o-information-circle')
                     ->hintColor('warning')
-                    ->imagePreviewHeight('150')
+                    ->imagePreviewHeight('250')
                     ->openable()
                     ->preserveFilenames()
                     ->downloadable()

--- a/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
+++ b/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
@@ -89,10 +89,10 @@ class CreateEvent extends CreateRecord
                     ->responsiveImages()
                     ->maxSize(1024 * 1000 * 2)
                     ->maxFiles(20)
-                    ->hint(__('Maximum size: '.Number::fileSize(1024 * 1000 * 1000 * 2).' bytes.'))
+                    ->hint(__('Maximum size: ' . Number::fileSize(1024 * 1000 * 1000 * 2) . ' bytes.'))
                     ->hintIcon('heroicon-o-information-circle')
                     ->hintColor('warning')
-                    ->imagePreviewHeight('250')
+                    ->imagePreviewHeight('300')
                     ->openable()
                     ->getUploadedFileNameForStorageUsing(
                         fn (TemporaryUploadedFile $file): string => (string) str($file->getClientOriginalName())
@@ -101,11 +101,15 @@ class CreateEvent extends CreateRecord
                     ->reorderable()
                     ->appendFiles()
                     ->moveFiles()
-                    ->preserveFilenames()
                     ->downloadable()
-                    ->imageEditor(2)
+                    ->imageEditor(3)
                     ->imageEditorEmptyFillColor('#dda581')
-                    ->uploadingMessage(__('uploading, please wait...')),
+                    ->imageResizeMode('cover')
+                    ->imageCropAspectRatio('4:3')
+                    ->imageResizeTargetWidth('380')
+                    ->imageResizeTargetHeight('350')
+                    ->uploadingMessage(__('uploading, please wait...'))
+                    ->columnSpanFull(),
 
             ]);
     }

--- a/app/Filament/Clusters/Frontends/Resources/FoundersCommitteeResource/Pages/CreateFoundersCommittee.php
+++ b/app/Filament/Clusters/Frontends/Resources/FoundersCommitteeResource/Pages/CreateFoundersCommittee.php
@@ -42,7 +42,7 @@ class CreateFoundersCommittee extends CreateRecord
                     ->hint(__('Maximum size: 3MB.'))
                     ->hintIcon('heroicon-o-information-circle')
                     ->hintColor('warning')
-                    ->imagePreviewHeight('150')
+                    ->imagePreviewHeight('250')
                     ->openable()
                     ->preserveFilenames()
                     ->downloadable()

--- a/app/Filament/Clusters/Frontends/Resources/HomepageResource/Pages/CreateHomepage.php
+++ b/app/Filament/Clusters/Frontends/Resources/HomepageResource/Pages/CreateHomepage.php
@@ -52,7 +52,7 @@ class CreateHomepage extends CreateRecord
                                     ->hint(__('Maximum size: '.Number::fileSize(1024 * 1000 * 1000 * 1).' bytes.'))
                                     ->hintIcon('heroicon-o-information-circle')
                                     ->hintColor('warning')
-                                    ->imagePreviewHeight('150')
+                                    ->imagePreviewHeight('250')
                                     ->openable()
                                     ->preserveFilenames()
                                     ->downloadable()


### PR DESCRIPTION
- Increase image preview height to 250 pixels in CreateBoardOfTrustee, CreateEvent, CreateFoundersCommittee, and CreateHomepage pages.
- Improve user experience by providing a larger preview of uploaded images.