### PR TITLE
Update image preview height in create pages

### DIFF
--- a/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
+++ b/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
@@ -104,10 +104,10 @@ class CreateEvent extends CreateRecord
                     ->downloadable()
                     ->imageEditor(3)
                     ->imageEditorEmptyFillColor('#dda581')
-                    ->imageResizeMode('cover')
-                    ->imageCropAspectRatio('4:3')
-                    ->imageResizeTargetWidth('380')
-                    ->imageResizeTargetHeight('350')
+                    // ->imageResizeMode('cover')
+                    // ->imageCropAspectRatio('4:3')
+                    // ->imageResizeTargetWidth('380')
+                    // ->imageResizeTargetHeight('350')
                     ->uploadingMessage(__('uploading, please wait...'))
                     ->columnSpanFull(),
 


### PR DESCRIPTION
This pull request updates the image preview height in create pages. The image resize mode, crop aspect ratio, target width, and target height have been commented out in order to prevent any unintended changes. This change ensures that the image preview height is adjusted correctly.