### PR TITLE
Update event description editor and image display

### DIFF
--- a/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
+++ b/app/Filament/Clusters/Frontends/Resources/EventResource/Pages/CreateEvent.php
@@ -6,9 +6,9 @@ use App\EventType;
 use App\Filament\Clusters\Frontends\Resources\EventResource;
 use Filament\Actions\LocaleSwitcher;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -48,8 +48,11 @@ class CreateEvent extends CreateRecord
                 TextInput::make('event_slug')
                     ->label(__('Event Slug'))
                     ->required(),
-                Textarea::make('event_description')
+                RichEditor::make('event_description')
                     ->label(__('Event Description'))
+                    ->disableToolbarButtons([
+                        'attachFiles',
+                    ])
                     ->live(onBlur: true)
                     ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state) {
                         //                        if (($get('event_excerpt') ?? '') !== Str::limit($old, 100)) {
@@ -92,7 +95,7 @@ class CreateEvent extends CreateRecord
                     ->responsiveImages()
                     ->maxSize(1024 * 1000 * 2)
                     ->maxFiles(20)
-                    ->hint(__('Maximum size: ' . Number::fileSize(1024 * 1000 * 1000 * 2) . ' bytes.'))
+                    ->hint(__('Maximum size: '.Number::fileSize(1024 * 1000 * 1000 * 2).' bytes.'))
                     ->hintIcon('heroicon-o-information-circle')
                     ->hintColor('warning')
                     ->imagePreviewHeight('300')

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -73,9 +73,16 @@ class EventController extends Controller
         })->first();
 
         //get image at random
-        $randomImage = $event->media->filter(function ($media) {
-            return $media->mime_type !== 'video/mp4';
-        })->random();
+        if ($event->media->count() > 2) {
+            $randomImage = $event->media->filter(function ($media) {
+                return $media->mime_type !== 'video/mp4';
+            })->random();
+        } else {
+            $randomImage = null;
+        }
+        //        $randomImage = $event->media->filter(function ($media) {
+        //            return $media->mime_type !== 'video/mp4';
+        //        })->random() ?? null;
 
         return view('home.events.show', [
             'event' => $event,

--- a/resources/views/home/events/show.blade.php
+++ b/resources/views/home/events/show.blade.php
@@ -40,7 +40,7 @@
                         @endif
                     </div>
                 @endforelse
-                <p class="description-text">{{$event->event_description}}</p>
+                <p class="description-text">{!! $event->event_description !!}</p>
 
                 <!-- Image Carousel -->
                 <div class="slider">
@@ -174,9 +174,9 @@
 
     .empty-image-container img{
         width: 100%;
-        height: 35rem;
-        object-fit: cover;
-        object-position: center center;
+        height: 36rem;
+        object-fit: scale-down;
+        /*object-position: center center;*/
         border-radius: 1rem;
 
     }
@@ -239,10 +239,13 @@
 
     .description-text {
         margin-top: 2rem;
-        margin-bottom: 1rem;
+        margin-bottom: 1.5rem;
         font-size: 1.125rem;
-        line-height: 1.75rem;
+        line-height: 2rem;
         color: #1a202c;
+        /*fix paragraph spacing */
+        text-align: justify;
+        text-justify: inter-word;
     }
 
     @media (min-width: 1024px) {


### PR DESCRIPTION
This pull request updates the event description editor to use a RichEditor component instead of a Textarea component. The RichEditor component disables the toolbar button for attaching files. Additionally, the pull request modifies the image display on the event show page. If the event has more than 2 images, a random image is selected from the media collection. If the event has 2 or fewer images, no random image is selected. The pull request also updates the CSS for the image container and the description text to improve the layout and spacing.