### PR TITLE
feat: Update membership ID generation logic

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -595,7 +595,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia,
     public function generateUniqueMembershipId()
     {
         do {
-            $membershipId = 'APSF' . now()->format('YmdHis') . $this->profile_short_code() . strtoupper(substr($this->getUserCountry(), 0, 2));
+            $membershipId = 'APSF' . now()->format('YmdHis') . $this->profile_short_code() . $this->getUserCountry();
         } while (User::where('membership_id', $membershipId)->exists());
 
         return $membershipId;


### PR DESCRIPTION
The membership ID generation logic in the `generateUniqueMembershipId` method of the `User` model has been updated. Instead of using the uppercase abbreviation of the user's country, the full name of the country is now used. This change ensures that the generated membership IDs are more descriptive and easier to understand.